### PR TITLE
list builder gui bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ luac.out
 *.x86_64
 *.hex
 
+/List Builder/__pycache__

--- a/List Builder/GUI.py
+++ b/List Builder/GUI.py
@@ -59,7 +59,7 @@ def current_folder_2():
 def build_list():
     global text
     process = subprocess.Popen(
-        sys.executable+" -u \""+os.getcwd()+"/list_builder.py\" \""+selected.get()+"\" \""+ent1.get()+"\" \""+ent2.get()+"\"",
+        "\""+sys.executable+"\" -u \""+os.getcwd()+"/list_builder.py\" \""+selected.get()+"\" \""+ent1.get()+"\" \""+ent2.get()+"\"",
         #"python -u list_builder.py "+selected.get()+" "+ent1.get()+" "+ent2.get(),
         stdout=subprocess.PIPE,
         universal_newlines=True,


### PR DESCRIPTION
surround the path for python in quotes.
this is needed on windows because of spaces in folder names.