### PR TITLE
bugifx for saving settings

### DIFF
--- a/XEBPLUS/APPS/neutrinoLauncher/settings.lua
+++ b/XEBPLUS/APPS/neutrinoLauncher/settings.lua
@@ -295,6 +295,9 @@ ContextMenu_NewSettings = ContextMenu_NewSettings..ContextMenu_DisableFade
 ContextMenu_NewSettings = ContextMenu_NewSettings..ContextMenu_DisableAnim
 ContextMenu_NewSettings = ContextMenu_NewSettings..ContextMenu_ShowTitleId
 ContextMenu_NewSettings = ContextMenu_NewSettings..ContextMenu_ShowMedia
+if not System.doesDirectoryExist("mass:/XEBPLUS/CFG/neutrinoLauncher") then
+	System.createDirectory("mass:/XEBPLUS/CFG/neutrinoLauncher")
+end
 if ContextMenu_NewSettings == "" then
     System.removeFile(System.currentDirectory().."CFG/neutrinoLauncher/menu.cfg")
 else


### PR DESCRIPTION
make sure that the CFG/neutrinoLauncher folder exists before saving menu.cfg . This prevents a crash if someone tries to change settings before running neutrinoLauncher.lua