### PR TITLE
Fix history file parsing

### DIFF
--- a/XEBPLUS/APPS/neutrinoLauncher/neutrinoLauncher.lua
+++ b/XEBPLUS/APPS/neutrinoLauncher/neutrinoLauncher.lua
@@ -1922,8 +1922,7 @@ while XEBKeepInSubMenu do
 
 			NEUTRINO_PrepIRX = ""
 			if string.match(NEUTRINO_Bsd, "(.*)udp(.*)") then
-				--NEUTRINO_PrepIRX = "echo \""..neuLang[15].."\"\r\nload modules/ps2dev9.irx\r\nload modules/netman.irx\r\nload modules/smap.irx\r\nsleep 3\r\n"
-				NEUTRINO_PrepIRX = "load modules/dev9_ns.irx\r\necho \""..neuLang[15].."\"\r\nsleep 3\r\n"
+				NEUTRINO_PrepIRX = "echo \""..neuLang[15].."\"\r\nload modules/ps2dev9.irx\r\nload modules/netman.irx\r\nload modules/smap.irx\r\nsleep 3\r\n"
 			end
 
 			NEUTRINO_GameFolder = NEUTRINO_CurrentList[NEUTRINO_SelectedItem].Folder.."/"

--- a/XEBPLUS/APPS/neutrinoLauncher/neutrinoLauncher.lua
+++ b/XEBPLUS/APPS/neutrinoLauncher/neutrinoLauncher.lua
@@ -1872,13 +1872,13 @@ while XEBKeepInSubMenu do
 				else
 					System.closeFile(NEUTRINO_TempFile)
 					
-					NEUTRINO_TempFile = io.open("mc0:/BADATA-SYSTEM/history", "r")
-					NEUTRINO_PlayCount = NEUTRINO_TempFile:read()
+					NEUTRINO_TempFile = io.open("mc0:/BADATA-SYSTEM/history", "rb")
+					NEUTRINO_TempFile:seek("set", 16)
+					NEUTRINO_PlayCount = NEUTRINO_TempFile:read(1)
 					io.close(NEUTRINO_TempFile)
-					NEUTRINO_PlayCount = string.sub(NEUTRINO_PlayCount, 17, 17)
 					NEUTRINO_PlayCount = string.byte(NEUTRINO_PlayCount)
 					
-					NEUTRINO_PlayCount = tonumber(NEUTRINO_PlayCount) + 1
+					NEUTRINO_PlayCount = NEUTRINO_PlayCount + 1
 					if NEUTRINO_PlayCount >= 64 then
 						NEUTRINO_PlayCount = 1
 					end


### PR DESCRIPTION
This PR fixes a crash that occurs when reading and parsing the history file.  
https://github.com/sync-on-luma/xebplus-neutrino-loader-plugin/issues/39

This also reintroduced the changes made in a previous PR.  
https://github.com/sync-on-luma/xebplus-neutrino-loader-plugin/pull/37