### PR TITLE
Bugfix for extra space

### DIFF
--- a/XEBPLUS/APPS/neutrinoLauncher/neutrinoLauncher.lua
+++ b/XEBPLUS/APPS/neutrinoLauncher/neutrinoLauncher.lua
@@ -1870,7 +1870,7 @@ while XEBKeepInSubMenu do
 			end
 
 			if string.match(NEUTRINO_LaunchOptions, "(.*)vmc(.*)") then
-				NEUTRINO_LaunchOptions = string.sub(NEUTRINO_LaunchOptions, 5, string.len(NEUTRINO_LaunchOptions))
+				NEUTRINO_LaunchOptions = string.sub(NEUTRINO_LaunchOptions, 6, string.len(NEUTRINO_LaunchOptions))
 				if NEUTRINO_CurrentList[NEUTRINO_SelectedItem].Vmc ~= "0000000000000000000000" and NEUTRINO_CurrentList[NEUTRINO_SelectedItem].Vmc ~= nil then
 					NEUTRINO_Vmc = " -mc0="..NEUTRINO_PathPrefix..":"..NEUTRINO_CurrentList[NEUTRINO_SelectedItem].Vmc
 				end


### PR DESCRIPTION
If there is a trailing space in the neutrino command line arguments, neutrino will throw an error and exit to browser. If valid vmc info is present this does not matter because the vmc argument is added after the space. The issue is when a list without vmc info is used and NEUTRINO_LaunchOptions still has the '-vmc ' flag. This just removes the extra space at the end to ensure that no trailing space is present.