### PR TITLE
add ContextMenu control for ata-net or udpbd-hdd

### DIFF
--- a/XEBPLUS/APPS/neutrinoLauncher/neutrinoLang.lua
+++ b/XEBPLUS/APPS/neutrinoLauncher/neutrinoLang.lua
@@ -93,6 +93,10 @@ if XEBPlusLanguage == "en-US" then
     neuLang[91] = "Launch HDL format games from the hard drive"
     neuLang[92] = "Enable Debug Colors"
     neuLang[93] = "Flash a series of colors on launch.\nThis can help diagnose titles that will\nnot start."
+    neuLang[94] = "Enable in game Networking"
+    neuLang[95] = "Used for games with Online/LAN support"
+    neuLang[96] = "Enable in game HDD access"
+    neuLang[97] = "Used for games with HDD support"
 
     NEUTRINO_Control1 = "image/controlmap1.png"
     NEUTRINO_Control2 = "image/controlmap2.png"
@@ -193,6 +197,10 @@ elseif XEBPlusLanguage == "es-419" then
     neuLang[91] = "Ejecutar juegos en formato HDL desde el disco duro"
     neuLang[92] = "Habilitar colores de depuración"
     neuLang[93] = "Muestra una serie de colores al iniciarse.\nEsto puede ayudar a diagnosticar títulos\nque no inicien."
+    neuLang[94] = "Habilitar la red dentro del juego"
+    neuLang[95] = "Utiliza para juegos en línea/LAN"
+    neuLang[96] = "Habilite el disco duro"
+    neuLang[97] = "Se utiliza para juegos compatibles\ncon disco duro."
 
     NEUTRINO_Control1 = "image/controlmap1_es.png"
     NEUTRINO_Control2 = "image/controlmap2_es.png"
@@ -293,6 +301,10 @@ elseif XEBPlusLanguage == "pt-BR" then
     neuLang[91] = "Inicialize jogos no formato HDL a partir do disco rígido"
     neuLang[92] = "Ativar cores de depuração"
     neuLang[93] = "Mostra uma série de cores no lançamento.\nIsto pode ajudar a diagnosticar títulos\nque não iniciam."
+    neuLang[94] = "Ativar rede no jogo"
+    neuLang[95] = "Usado para jogos com suporte Online/LAN"
+    neuLang[96] = "Ative o disco rígido"
+    neuLang[97] = "Usado para jogos com suporte\na disco rígido."
 
     NEUTRINO_Control1 = "image/controlmap1_pt.png"
     NEUTRINO_Control2 = "image/controlmap2_pt.png"

--- a/XEBPLUS/APPS/neutrinoLauncher/neutrinoLauncher.lua
+++ b/XEBPLUS/APPS/neutrinoLauncher/neutrinoLauncher.lua
@@ -1290,6 +1290,22 @@ function ContextMenu_ReadSettings(Settings)
 		ContextMenu_Gz = ""
 		ContextMenu[12+ContextMenu_Offset].Name = neuLang[81]..neuLang[89]
 	end
+
+	if string.match(Settings, "(.*)atanet(.*)") then
+		ContextMenu_AltBSD = "atanet"
+		ContextMenu[14+ContextMenu_Offset].Name = "\194\172  "..neuLang[94]
+	else
+		ContextMenu_AltBSD = ""
+		ContextMenu[14+ContextMenu_Offset].Name = "     "..neuLang[94]
+	end
+
+	if string.match(Settings, "(.*)udpbdhdd(.*)") then
+		ContextMenu_AltBSD = "udpbdhdd"
+		ContextMenu[14+ContextMenu_Offset].Name = "\194\172  "..neuLang[96]
+	else
+		ContextMenu_AltBSD = ""
+		ContextMenu[14+ContextMenu_Offset].Name = "     "..neuLang[96]
+	end
 end
 ContextMenu_FirstRun = true
 function NEUTRINO_ContextMenu()
@@ -1302,6 +1318,10 @@ function NEUTRINO_ContextMenu()
 		ContextMenu_Offset = 1
 		ContextMenu_EnableVmc = true
 		ContextMenu_EnableUnique = false
+		ContextMenu_AltBSD = ""
+		ContextMenu_EnableAltBSD = false
+		ContextMenu_EnableATANet = false
+		ContextMenu_EnableUDPBDHDD = false
 		
 		if string.match(NEUTRINO_CheckGroups(NEUTRINO_CurrentList[NEUTRINO_SelectedItem].TitleId), "(.*)XEBP(.*)") then
 			ContextMenu_Offset = ContextMenu_Offset + 1
@@ -1312,25 +1332,25 @@ function NEUTRINO_ContextMenu()
 			ContextMenu_EnableVmc = false
 		end
 			
-		ContextMenu={};
-		ContextMenu[1] = {};
-		ContextMenu[2] = {};
-		ContextMenu[3] = {};
-		ContextMenu[4] = {};
-		ContextMenu[5] = {};
-		ContextMenu[6] = {};
-		ContextMenu[7] = {};
-		ContextMenu[8] = {};
-		ContextMenu[9] = {};
-		ContextMenu[10] = {};
-		ContextMenu[11] = {};
-		ContextMenu[12] = {};
-		ContextMenu[13] = {};
-		if ContextMenu_Offset > 0 then
-			ContextMenu[14] = {};
+		if NEUTRINO_Bsd == "ata" then
+			ContextMenu_EnableAltBSD = true
+			ContextMenu_EnableATANet = true
+		elseif NEUTRINO_Bsd == "udpbd" then
+			ContextMenu_EnableAltBSD = true
+			ContextMenu_EnableUDPBDHDD = true
 		end
-		if ContextMenu_Offset == 2 then
-			ContextMenu[15] = {};
+
+		ContextMenu={};
+		for i = 1, 13+ContextMenu_Offset do
+			ContextMenu[i] = {};
+		end
+		if ContextMenu_EnableAltBSD == true then
+			ContextMenu[14+ContextMenu_Offset] = {};
+			if ContextMenu_EnableUDPBDHDD then
+				ContextMenu[14+ContextMenu_Offset].Description = neuLang[97]
+			else
+				ContextMenu[14+ContextMenu_Offset].Description = neuLang[95]
+			end
 		end
 
 		ContextMenu[1].Description = neuLang[21]
@@ -1355,6 +1375,9 @@ function NEUTRINO_ContextMenu()
 
 		ContextMenu_AllItems = 13 + ContextMenu_Offset
 		
+		if ContextMenu_EnableAltBSD == true then
+			ContextMenu_AllItems = ContextMenu_AllItems + 1
+		end
 		if System.doesFileExist(NEUTRINO_DataFolder..NEUTRINO_CurrentList[NEUTRINO_SelectedItem].Name..".cfg") then
 			NEUTRINO_TempFile = io.open(NEUTRINO_DataFolder..NEUTRINO_CurrentList[NEUTRINO_SelectedItem].Name..".cfg", "r")
 			ContextMenu_LocalSettings = NEUTRINO_TempFile:read()
@@ -1613,6 +1636,24 @@ function NEUTRINO_ContextMenu()
 					NEUTRINO_TempFile:write(NEUTRINO_ArtTotal)
 					NEUTRINO_TempFile:close()
 				end
+			elseif ContextMenu_EnableAltBSD == true and ContextMenu_SelectedItem == 14+ContextMenu_Offset then
+				if ContextMenu_EnableATANet == true then
+					if ContextMenu_AltBSD == "" then
+						ContextMenu[14+ContextMenu_Offset].Name = "\194\172  "..neuLang[94]
+						ContextMenu_AltBSD = "atanet"
+					else
+						ContextMenu[14+ContextMenu_Offset].Name = "     "..neuLang[94]
+						ContextMenu_AltBSD = ""
+					end
+				elseif ContextMenu_EnableUDPBDHDD == true then
+					if ContextMenu_AltBSD == "" then
+						ContextMenu[14+ContextMenu_Offset].Name = "\194\172  "..neuLang[96]
+						ContextMenu_AltBSD = "udpbdhdd"
+					else
+						ContextMenu[14+ContextMenu_Offset].Name = "     "..neuLang[96]
+						ContextMenu_AltBSD = ""
+					end
+				end
 			end
 			if ContextMenu_Gy == "" and ContextMenu_Gz ~= "" then
 				ContextMenu_Gy = ":"
@@ -1648,6 +1689,7 @@ function NEUTRINO_ContextMenu()
 		ContextMenu_NewSettings = ContextMenu_NewSettings..ContextMenu_Gx
 		ContextMenu_NewSettings = ContextMenu_NewSettings..ContextMenu_Gy
 		ContextMenu_NewSettings = ContextMenu_NewSettings..ContextMenu_Gz
+		ContextMenu_NewSettings = ContextMenu_NewSettings..ContextMenu_AltBSD
 
 		if ContextMenu_Global == false then
 			if ContextMenu_NewSettings ~= ContextMenu_GlobalSettings or System.doesFileExist(NEUTRINO_DataFolder..NEUTRINO_CurrentList[NEUTRINO_SelectedItem].Name..".cfg") then
@@ -1942,6 +1984,14 @@ while XEBKeepInSubMenu do
 			NEUTRINO_GameFolder = NEUTRINO_CurrentList[NEUTRINO_SelectedItem].Folder.."/"
 			if string.match(NEUTRINO_Fs, "(.*)hdl(.*)") then
 				NEUTRINO_GameFolder = ""
+			end
+
+			if string.match(NEUTRINO_Bsd, "ata") and string.match(NEUTRINO_LaunchOptions, "(.*)atanet(.*)") then
+				NEUTRINO_LaunchOptions = string.sub(NEUTRINO_LaunchOptions, 7, string.len(NEUTRINO_LaunchOptions))
+				NEUTRINO_Bsd = "ata-net"
+			elseif string.match(NEUTRINO_Bsd, "udpbd") and string.match(NEUTRINO_LaunchOptions, "(.*)udpbdhdd(.*)") then
+				NEUTRINO_LaunchOptions = string.sub(NEUTRINO_LaunchOptions, 9, string.len(NEUTRINO_LaunchOptions))
+				NEUTRINO_Bsd = "udpbd-hdd"
 			end
 
 			System.removeFile(xebLua_AppWorkingPath.."radshellmod.ios")


### PR DESCRIPTION
This adds a new entry in the context menu to allow global or per-game toggling of the ata-net or udpbd-hdd backing store drivers.

more info:
https://github.com/rickgaiser/neutrino/issues/129#issuecomment-3249301144